### PR TITLE
set overflow to hidden

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,6 +249,7 @@
         align-items: center;
         justify-content: center;
         height: 100vh;
+        overflow: hidden;
         margin-left: auto;
         margin-right: auto;
       }


### PR DESCRIPTION
fixes sparkleDivs causing page size to increase when the mouse is near edge.